### PR TITLE
set interface language as en

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ let scholar = (function () {
   let cheerio = require('cheerio')
   let striptags = require('striptags')
 
-  const GOOGLE_SCHOLAR_URL = 'https://scholar.google.com/scholar?q='
+  const GOOGLE_SCHOLAR_URL = 'https://scholar.google.com/scholar?hl=en&q='
   const GOOGLE_SCHOLAR_URL_PREFIX = 'https://scholar.google.com'
 
   const ELLIPSIS_HTML_ENTITY = '&#x2026;'


### PR DESCRIPTION
thank you for distributing google-scholar search package.

If interface language `(hl=)` is not specified in web request, `citedCount` / `relatedUrl` parsing fails as the following.

```
authors:Array[2],
citedCount:0,
citedUrl:"https://scholar.google.com/scholar?cites=9692529718922546949&as_sdt=2005&sciodt=0,5&hl=ja",
relatedUrl:""
```

In this case, `hl=ja` is filled in implicitly when sending request,
and the results (ja interface) cannot be parsed by english keywords.
https://github.com/VT-CHCI/google-scholar/blob/master/index.js#L13..L14